### PR TITLE
Fix deobfuscation for single space vars

### DIFF
--- a/batch_deobfuscator/batch_interpreter.py
+++ b/batch_deobfuscator/batch_interpreter.py
@@ -213,7 +213,7 @@ class BatchDeobfuscator:
                     # Usually an output redirection, we want to keep it on the same line
                     pass
                 elif char == "&" or char == "|":
-                    cmd = logical_line[start_command:counter].strip()
+                    cmd = logical_line[start_command:counter].strip("\r\n")
                     if cmd != "":
                         for part in self.get_commands_special_statement(cmd):
                             yield part
@@ -226,13 +226,12 @@ class BatchDeobfuscator:
 
             counter += 1
 
-        last_com = logical_line[start_command:].strip()
+        last_com = logical_line[start_command:].strip("\r\n")
         if last_com != "":
             for part in self.get_commands_special_statement(last_com):
                 yield part
 
     def get_value(self, variable):
-
         str_substitution = (
             r"([%!])(?P<variable>[^\n\x25]+)"
             r"("


### PR DESCRIPTION
When a variable is set to a single space (`Set Var= `), the space is lost because `get_commands()` iterates lines and calls `.strip()` on each line.

This has been fixed by limiting the strip operation to newlines.